### PR TITLE
Make expensive resource allocation code more painful. Add new test (still failing).

### DIFF
--- a/id-fix.js
+++ b/id-fix.js
@@ -22,9 +22,9 @@ if (	typeof (NAMESPACE) == 'undefined'  	) {
         //var _closed = false;
         //var _id = id;
         //var _expensive_resource = null;
-		
-		
-		var 
+
+
+		var
 			// _closed = false =====> not being used
 			//  _all_ids ======> not necessary var
 			 _id = id
@@ -33,8 +33,8 @@ if (	typeof (NAMESPACE) == 'undefined'  	) {
 			, getExpensiveResource
 			, getId
 			, close
-		
-		
+
+
         // Public data
 		// XXX bad pratice, too many var statements XXX //
         //var persona = { };
@@ -43,33 +43,33 @@ if (	typeof (NAMESPACE) == 'undefined'  	) {
         getExpensiveResource = function () {
             return _expensive_resource;
         }
-        
+
         persona.getExpensiveResource = getExpensiveResource;
 
         getId = function () {
             return _id;
         }
-        
+
         persona.getId = getId;
 
         close = function () {
            	// XXXX delete is for associative arrays
 			// XXXX _all_ids is not necessary on this code
 			// delete _all_ids[_id];
-            
+
 			// XXXXX this flag is not being used on any other place of the code
 			this._closed = true;
         }
 
         persona.close = close;
-        
+
         // Private methods
         function _lookupOrCreateExpensiveResourceById(id) {
-            
+
 			// XXXXXX handling _all_ids is very unnecessary due it does not provide any public way to set a different value to it.
-			
+
 			//_expensive_resource = _all_ids[id];
-            
+
             //if (_expensive_resource == null) {
                 // Just pretend for the sake of this example
                 _expensive_resource = {
@@ -78,16 +78,16 @@ if (	typeof (NAMESPACE) == 'undefined'  	) {
 
                 //_all_ids[id] = _expensive_resource;
             //}
-            
+
             return _expensive_resource;
         }
-        
+
         // Initialization
         _expensive_resource = _lookupOrCreateExpensiveResourceById(id);
-        
+
         return persona;
     }
 
     NAMESPACE.resource = resource;
-	
+
 }

--- a/id-fix.js
+++ b/id-fix.js
@@ -11,6 +11,36 @@
 if (	typeof (NAMESPACE) == 'undefined'  	) {
     window['NAMESPACE'] = {};
 
+    NAMESPACE._resources_created = 0; // Can we make this less accessible somehow?
+
+    var createExpensiveResource = function (params) {
+        // Just pretend for now (hint: you do not want this code to run
+        // more than is absolutely necessary)
+        var millis = 3000;
+        console.log('busy waiting for ' + millis + ' ms...');
+        var start = +(new Date());
+        while (new Date() - start < millis);
+        var end = +(new Date());
+        console.log('done!');
+
+        var _expensive_resource = {
+            start: start,
+            end: end,
+            value: "I'm a very expensive resource associated with ID " + params.id
+        };
+
+        ++NAMESPACE._resources_created;
+
+        return _expensive_resource;
+    };
+
+    NAMESPACE.createExpensiveResource = createExpensiveResource;
+
+    var getTotalExpensiveResourcesCreated = function () {
+        return NAMESPACE._resources_created;
+    };
+
+    NAMESPACE.getTotalExpensiveResourcesCreated = getTotalExpensiveResourcesCreated;
 
     // Creates an object that allocates a new or references an
     // existing very expensive resource associated with `id`
@@ -71,10 +101,7 @@ if (	typeof (NAMESPACE) == 'undefined'  	) {
 			//_expensive_resource = _all_ids[id];
 
             //if (_expensive_resource == null) {
-                // Just pretend for the sake of this example
-                _expensive_resource = {
-                    value: "I'm a very expensive resource associated with ID " + id
-                };
+                _expensive_resource = createExpensiveResource({ id: id });
 
                 //_all_ids[id] = _expensive_resource;
             //}

--- a/t.js
+++ b/t.js
@@ -49,11 +49,13 @@
 	});
 
 
-	//QUnit.test( "check reallocating resource", function( assert ) {
-	//  assert.ok( resource.getExpensiveResource() === resource2.getExpensiveResource(), "unnecessarily reallocating resource(Eduardo)" );
-	//});
+	QUnit.test( "check reallocating resource", function( assert ) {
+	 assert.ok( resource.getExpensiveResource() === resource2.getExpensiveResource(), "unnecessarily reallocating resource(Eduardo)" );
+	});
 
 
 	QUnit.test( "compare expensiveResources with same id", function( assert ) {
-	  assert.ok( resource.getExpensiveResource().value === resource2.getExpensiveResource().value, "equal" );
+	  assert.ok( resource.getExpensiveResource().start === resource2.getExpensiveResource().start, "unnecessarily reallocating resource(Eduardo)" );
+	  assert.ok( resource.getExpensiveResource().end === resource2.getExpensiveResource().end, "unnecessarily reallocating resource(Eduardo)" );
+	  assert.ok( resource.getExpensiveResource().value === resource2.getExpensiveResource().value, "unnecessarily reallocating resource(Eduardo)" );
 	});

--- a/t.js
+++ b/t.js
@@ -1,59 +1,59 @@
 	var resource = new NAMESPACE.resource('Eduardo');  // working
 	resource.close(); // working
-			
-			
+
+
 	var resource2 = new NAMESPACE.resource('Eduardo');  // working
-	
+
 	resource2.close(); // working
-  
-  
+
+
   	QUnit.test( "check resource variable type", function( assert ) {
 	  assert.ok( ((typeof resource == "object") && (resource !== null) && (Object.prototype.toString.call(resource) !== '[object Array]')), "Passed!" );
 	});
-	
+
 	QUnit.test( "check resource2 variable type", function( assert ) {
 	  assert.ok( ((typeof resource2 == "object") && (resource2 !== null) && (Object.prototype.toString.call(resource2) !== '[object Array]')), "Passed!" );
 	});
-	
-	
+
+
 	QUnit.test( "check resource id", function( assert ) {
 	  assert.ok( resource.getId() === 'Eduardo', "Passed!" );
 	});
-	
-	
+
+
 	QUnit.test( "check resource's ExpensiveResource", function( assert ) {
 	  assert.ok( resource.getExpensiveResource().value === "I'm a very expensive resource associated with ID Eduardo", "Passed!" );
 	});
-	
+
 	QUnit.test( "resource is closed", function( assert ) {
 	  assert.ok( resource._closed === true, "Passed!" );
 	});
-	
-	
+
+
 	QUnit.test( "check resource2 id", function( assert ) {
 	  assert.ok( resource2.getId() === 'Eduardo', "Passed!" );
 	});
-	
-	
+
+
 	QUnit.test( "check resource2's ExpensiveResource", function( assert ) {
 	  assert.ok( resource2.getExpensiveResource().value === "I'm a very expensive resource associated with ID Eduardo", "Passed!" );
 	});
-	
+
 	QUnit.test( "resource2 is closed", function( assert ) {
 	  assert.ok( resource._closed === true, "Passed!" );
 	});
-	
-	
+
+
 	QUnit.test( "resource and resource2 are different instances", function( assert ) {
 	  assert.ok( resource !== resource2, "Passed!" );
 	});
-	
-	
+
+
 	//QUnit.test( "check reallocating resource", function( assert ) {
 	//  assert.ok( resource.getExpensiveResource() === resource2.getExpensiveResource(), "unnecessarily reallocating resource(Eduardo)" );
 	//});
-	
-	
+
+
 	QUnit.test( "compare expensiveResources with same id", function( assert ) {
 	  assert.ok( resource.getExpensiveResource().value === resource2.getExpensiveResource().value, "equal" );
 	});


### PR DESCRIPTION
@web2solutions wrote:

> Your test will never pass if the returned value is a object literal
> 
> ``` js
>                 _expensive_resource = {
>                     value: "I'm a very expensive resource associated with ID " + id
>          };
> ```
> 
> The same happens here:
> 
> ``` js
>             var aa1 = {
>                 value : 1    
>             };
>             var aa2 = {
>                 value : 1    
>             };
>             console.log( aa1 === aa2 ); // false
> ```
> 
> But, if you let me change the returned value to a string, I can make it pass
> 
> ``` js
> _expensive_resource = "I'm a very expensive resource associated with ID " + id
> ```

@web2solutions, again, my apologies for not being clear. My proposed test should pass as written without converting the underlying object to a string.

Do you know what functionality my test is designed to check? Can you explain what the `===` operator does in this context?

This PR should make things clearer. I have re-enabled the test (which should now fail) and made new expensive resource allocation code more painful to illustrate [my earlier point](https://github.com/web2solutions/Veritaseum-proof-of-concept/commit/e6cb8cc8e6dff9c22c65dd3468a76731f13fd842#commitcomment-13580908).

As an aside, I noticed you are using a mixture of tabs and spaces in your code. This is generally not a very good practice and tends to frustrate other developers working on the same project. One normally picks one or the other. Where one indents in multiples of two, spaces are appropriate.

Also, your white space conventions are different from the original code. One usually adopts the white space conventions of the original unless there's a very good reason to change it.
